### PR TITLE
Fix week numbering

### DIFF
--- a/liturgical_colour/funcs.py
+++ b/liturgical_colour/funcs.py
@@ -33,14 +33,21 @@ def date_to_days(year, month, day):
 
 def day_of_week(year, month, day):
     """
-    Return ISO day of week for any given date in year,month,day format
+    Return day of week for any given date in year,month,day format
+    between 0-6 where 0 is Sunday, i.e. the first day of the week
+    Compare with:
+      weekday() which is 0-6 and 0 is Monday
+      isoweekday() which is 1-7 and 1 is Monday
     """
 
     # Define a start date as passed in
     f_date = date(year, month, day)
 
-    # Return ISO week day, in range 1-7
-    return f_date.isoweekday()
+    # Get ISO week day, in range 1-7
+    wd = f_date.isoweekday()
+    
+    # Rewrite 7=Sunday as 0=Sunday
+    return 0 if wd == 7 else wd
 
 def add_delta_days(days):
     """

--- a/liturgical_colour/funcs.py
+++ b/liturgical_colour/funcs.py
@@ -44,10 +44,10 @@ def day_of_week(year, month, day):
     f_date = date(year, month, day)
 
     # Get ISO week day, in range 1-7
-    wd = f_date.isoweekday()
-    
+    weekday = f_date.isoweekday()
+
     # Rewrite 7=Sunday as 0=Sunday
-    return 0 if wd == 7 else wd
+    return 0 if weekday == 7 else weekday
 
 def add_delta_days(days):
     """

--- a/liturgical_colour/liturgical.py
+++ b/liturgical_colour/liturgical.py
@@ -72,7 +72,7 @@ def liturgical_colour(s_date: str, transferred: bool = False):
     if easter_point > -47 and easter_point < 0:
         season = 'Lent'
         season_url = 'https://en.wikipedia.org/wiki/Lent'
-        weekno = (easter_point+50) // 7
+        weekno = (easter_point+50-dayofweek) // 7
         # The ECUSA calendar seems to indicate that Easter Eve ends
         # Lent *and* begins the Easter season. I'm not sure how. Maybe it's
         # in both? Maybe the daytime is in Lent and the night is in Easter?
@@ -91,11 +91,11 @@ def liturgical_colour(s_date: str, transferred: bool = False):
         # The Twelve Days of Christmas.
         season = 'Christmas'
         season_url = 'https://en.wikipedia.org/wiki/Christmastide'
-        weekno = 1 + christmas_point // 7
+        weekno = 1 + (christmas_point - dayofweek) // 7
     elif christmas_point >= 12 and christmas_point < 40:
         season = 'Epiphany'
         season_url = 'https://en.wikipedia.org/wiki/Epiphany_season'
-        weekno = 1 + (christmas_point-12) // 7
+        weekno = 1 + (christmas_point-12-dayofweek) // 7
     elif christmas_point >= 40 and easter_point <= -47:
         # Period of Ordinary Time after Epiphany
         season = 'Ordinary Time'

--- a/liturgical_colour/liturgical.py
+++ b/liturgical_colour/liturgical.py
@@ -36,6 +36,7 @@ def liturgical_colour(s_date: str, transferred: bool = False):
     year = f_date.year
     month = f_date.month
     day = f_date.day
+    dayofweek = day_of_week(year, month, day)
 
     #die "Need to specify year, month and day" unless $y and $m and $d;
 
@@ -128,7 +129,7 @@ def liturgical_colour(s_date: str, transferred: bool = False):
             possibles.append(transferred_feast)
 
     # Maybe a Sunday.
-    if day_of_week(year, month, day) == 7:
+    if dayofweek == 7:
         possibles.append({ 'prec': 5, 'type': 'Sunday', 'name': f"{season} {weekno}" })
 
     # So, which event takes priority?

--- a/liturgical_colour/liturgical.py
+++ b/liturgical_colour/liturgical.py
@@ -129,7 +129,7 @@ def liturgical_colour(s_date: str, transferred: bool = False):
             possibles.append(transferred_feast)
 
     # Maybe a Sunday.
-    if dayofweek == 7:
+    if dayofweek == 0:
         possibles.append({ 'prec': 5, 'type': 'Sunday', 'name': f"{season} {weekno}" })
 
     # So, which event takes priority?

--- a/liturgical_colour/liturgical.py
+++ b/liturgical_colour/liturgical.py
@@ -106,7 +106,7 @@ def liturgical_colour(s_date: str, transferred: bool = False):
         season = 'Ordinary Time'
         season_url = 'https://en.wikipedia.org/wiki/Ordinary_Time'
         weekno = 1 + (easter_point - 49) // 7
-    weekno = int(weekno)
+    weekno = int(weekno) if int(weekno) > 0 else None
 
     # Now, look for feasts.
     feast_from_easter    = lookup_feast(easter_point)
@@ -128,7 +128,9 @@ def liturgical_colour(s_date: str, transferred: bool = False):
             transferred_feast['name'] = transferred_feast['name'] + ' (transferred)'
             possibles.append(transferred_feast)
 
-    # Maybe a Sunday.
+    # Maybe a Sunday
+    # Shouldn't need to trap weekno=0 here, as the weekno increments on
+    # a Sunday so it can never be less than 1 on a Sunday
     if dayofweek == 0:
         possibles.append({ 'prec': 5, 'type': 'Sunday', 'name': f"{season} {weekno}" })
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -42,17 +42,18 @@ files = [
 
 [[package]]
 name = "dill"
-version = "0.3.7"
+version = "0.3.8"
 description = "serialize all of Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "dill-0.3.7-py3-none-any.whl", hash = "sha256:76b122c08ef4ce2eedcd4d1abd8e641114bfc6c2867f49f3c41facf65bf19f5e"},
-    {file = "dill-0.3.7.tar.gz", hash = "sha256:cc1c8b182eb3013e24bd475ff2e9295af86c1a38eb1aff128dac8962a9ce3c03"},
+    {file = "dill-0.3.8-py3-none-any.whl", hash = "sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7"},
+    {file = "dill-0.3.8.tar.gz", hash = "sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca"},
 ]
 
 [package.extras]
 graph = ["objgraph (>=1.7.2)"]
+profile = ["gprof2dot (>=2022.7.29)"]
 
 [[package]]
 name = "isort"
@@ -127,18 +128,18 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.1.0"
+version = "4.2.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.1.0-py3-none-any.whl", hash = "sha256:11c8f37bcca40db96d8144522d925583bdb7a31f7b0e37e3ed4318400a8e2380"},
-    {file = "platformdirs-4.1.0.tar.gz", hash = "sha256:906d548203468492d432bcb294d4bc2fff751bf84971fbb2c10918cc206ee420"},
+    {file = "platformdirs-4.2.0-py3-none-any.whl", hash = "sha256:0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068"},
+    {file = "platformdirs-4.2.0.tar.gz", hash = "sha256:ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-autodoc-typehints (>=1.24)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
+docs = ["furo (>=2023.9.10)", "proselint (>=0.13)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)"]
 
 [[package]]
 name = "pycodestyle"
@@ -292,5 +293,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.12"
-content-hash = "ac1704e2d69b79b31617d183ce3da08dec62c5b04aea6c596ab475b56182df3a"
+python-versions = "^3.11"
+content-hash = "1cf5b034b994a21938de112fc61d8156e630088dd8f0bd1b0265b58290b4dd3a"


### PR DESCRIPTION
* Change calendar weeks to start on Sundays, not Mondays
* Fix liturgical week numbers to increment on a Sunday, not necessarily 7 days after the start of the liturgical season
* Ignore liturgical week numbers of 0 (e.g. the days of Lent before the Sunday of Lent 1)

Fixes #19 