### PR TITLE
Fix crash on Sundays in non-numbered weeks like Holy Week

### DIFF
--- a/liturgical_calendar/funcs.py
+++ b/liturgical_calendar/funcs.py
@@ -128,7 +128,9 @@ def sunday_name(season: str, weekno: int) -> str:
     :return: Rendered name of the Sunday
     :rtype: str
     """
-    if weekno > 0:
+    if not weekno:
+        sunday = season
+    elif weekno > 0:
         sunday = f"{season} {weekno}"
     elif weekno < 1:
         weekno = abs(weekno)

--- a/liturgical_calendar/liturgical.py
+++ b/liturgical_calendar/liturgical.py
@@ -145,9 +145,9 @@ def liturgical_calendar(s_date: str, transferred: bool = False):
                 possibles.append(transferred_feast)
 
     # Handle Sundays. Every Sunday has some designation.
-    # Shouldn't need to trap weekno=0 here, as the weekno increments on
-    # a Sunday so it can never be less than 1 on a Sunday
-    if dayofweek == 0:
+    # weekno increments on a Sunday, so normally it can never be less than 1 on a Sunday
+    # except for seasons like Holy Week which don't have numbered Sundays, where weekno=None
+    if weekno and dayofweek == 0:
         possibles.append({ 'prec': 5, 'type': 'Sunday', 'name': sunday_name(season, weekno)})
 
         # Special Sundays. Use prec 8 here so they have the ability to transfer other feasts


### PR DESCRIPTION
Trap `weekno=None` which occurs in seasons where the weeks are not numbered (e.g. Holy Week).

Fixes #84 